### PR TITLE
Fix a bug that comes up when Plone 4 is patched against CSRF

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,8 @@ Changelog
 1.2 (unreleased)
 ----------------
 
-- Nothing changed yet.
+ - Fixed a problem with plone.protector for patched Plone 4s
+   (and possibly Plone 5). [simonedeponti]
 
 
 1.1.1 (2015-08-06)


### PR DESCRIPTION
The plugin needs to notify the user log-in so that the request is marked as safe and session writes that happen upon "log in" do not get rollbacked.

Without this fix, when CAS redirects back to Plone, since the token is missing from the request, the transaction is rolled back, and hence a second ticket validation is attempted (because after redirecting to the confirm page, the CAS ticket is still in the GET parameters). Since CAS does not allow two validations of the same ticket, everything breaks.

By notifying the event (only if it's a "login", i.e. this is a redirect from CAS and the ticket is valid) we trigger a subscriber in plone.protect that marks the current request as safe, therefore enabling the login to succeed.
